### PR TITLE
Fix error where baseTemplateUrl is not defined

### DIFF
--- a/libmoji.js
+++ b/libmoji.js
@@ -78,7 +78,7 @@ function buildPreviewUrl (pose, scale, gender, style, rotation, traits, outfit) 
 
 // returns the image url of a bitmoji comic with the specified paramters
 function buildCpanelUrl (comicId, avatarId, transparent, scale) {
-  return `${baseTemplateUrl}${comicId}-${avatarId}-v3.png?transparent=${transparent}&scale=${scale}`;
+  return `${baseCpanelUrl}${comicId}-${avatarId}-v3.png?transparent=${transparent}&scale=${scale}`;
 }
 
 // returns the image url of a bitmoji comic with the specified paramters

--- a/libmoji.js
+++ b/libmoji.js
@@ -83,7 +83,7 @@ function buildCpanelUrl (comicId, avatarId, transparent, scale) {
 
 // returns the image url of a bitmoji comic with the specified paramters
 function buildRenderUrl (comicId, avatarId, transparent, scale, outfit) {
-  return `${baseRenderUrl}${comicId}/${avatarId}-v3.png?transparent=${transparent}&scale=${scale}&outfit=${outfit}`;
+  return `${baseRenderUrl}${comicId}/${avatarId}-v3.png?transparent=${transparent}&scale=${scale}${outfit ? `&outfit=${outfit}` : ''}`;
 }
 
 // export all functions to be used


### PR DESCRIPTION
A `ReferenceError: baseTemplateUrl is not defined` was being thrown due to a misspelled variable.